### PR TITLE
Add NSE live tracking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,9 @@ https://brainrotbackground.s3.amazonaws.com/TRUCK-6.mp4
 https://brainrotbackground.s3.amazonaws.com/TRUCK-7.mp4
 https://brainrotbackground.s3.amazonaws.com/TRUCK-8.mp4
 https://brainrotbackground.s3.amazonaws.com/TRUCK-9.mp4
+
+### NSE Live Stock Tracking
+
+Run `npm run nse:live -- <SYMBOL>` to watch live prices from the NSE website.
+The script prints the latest price to the console every five seconds.
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "local": "next dev --hostname 0.0.0.0",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "nse:live": "node scripts/nse-live.mjs"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.554.0",

--- a/scripts/nse-live.mjs
+++ b/scripts/nse-live.mjs
@@ -1,0 +1,33 @@
+const symbol = process.argv[2] || 'NIFTY 50';
+
+async function fetchQuote(sym) {
+  const url = `https://www.nseindia.com/api/quote-equity?symbol=${encodeURIComponent(sym)}`;
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent': 'Mozilla/5.0',
+      'Accept': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Request failed with ${res.status}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  while (true) {
+    try {
+      const data = await fetchQuote(symbol);
+      const price = data?.priceInfo?.lastPrice;
+      console.log(`${new Date().toISOString()} - ${symbol}: ${price}`);
+    } catch (err) {
+      console.error('Error fetching data', err.message);
+    }
+    await new Promise(r => setTimeout(r, 5000));
+  }
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `nse-live.mjs` script to poll NSE website for live prices
- expose new script via `nse:live` npm script
- document how to use the script in the README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545e9fcab08323837f50e6f035bfee